### PR TITLE
Test/auth context

### DIFF
--- a/frontend/src/features/auth/context/AuthProvider.tsx
+++ b/frontend/src/features/auth/context/AuthProvider.tsx
@@ -23,9 +23,6 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
         (error.response.status >= 500 && error.response.status < 600))
     ) {
       setError(error.message);
-    } else {
-      const message = error instanceof Error ? error.message : String(error);
-      setError(message || "エラーが発生しました。");
     }
   };
 


### PR DESCRIPTION
# 変更点
- `AuthProvider`の`any`を消去
- `AuthProvider`のテストに失敗系を追加

# 今後の修正点
- `AuthProvider`のリファクタリング予定。エラーハンドリングのロジック関数を抜き出す。